### PR TITLE
Small kludge to allow Ruby 1.8 usage

### DIFF
--- a/lib/pleaserun/mustache_methods.rb
+++ b/lib/pleaserun/mustache_methods.rb
@@ -22,7 +22,9 @@ module PleaseRun::MustacheMethods
     # interpreted from POSIX 1003.1 2004 section 2.2.3 (Double-Quotes)
 
     # $ is has meaning, escape it.
-    value = str.gsub(/(?<![\\])\$/, "\\$")
+    # string reversal gets around using lookbehind
+    value = str.reverse.gsub(/(?:\$(?![\\]))/, "$\\").reverse
+
     # ` is has meaning, escape it.
     value = value.gsub(/`/) { "\\`" }
 

--- a/lib/pleaserun/platform/base.rb
+++ b/lib/pleaserun/platform/base.rb
@@ -149,7 +149,7 @@ class PleaseRun::Platform::Base
   # Get the platform name for this class.
   # The platform name is simply the lowercased class name, but this can be overridden by subclasses (but don't, because that makes things confusing!)
   def platform
-    self.class.name.split("::").last.gsub(/(?<=[^A-Z])[A-Z]+/, "-\\0").downcase
+    self.class.name.split("::").last.gsub(/(?:=[^A-Z])[A-Z]+/, "-\\0").downcase
   end # def platform
 
   # Get the template path for this platform.


### PR DESCRIPTION
This allowed me to get FPM functional on our older systems with Ruby 1.8.7.
While it worked for my needs, I fully understand if there's no desire to dirty up the code for the sake of ancient systems.